### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,38 @@ on:
       - 'deregister-sub.js'
       - 'helpers/**'
       - 'layer/**'
+      - 'docs/**'
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: lambda
+        template: docs/template.md
+  deploy:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,29 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/auto-deregister-sub)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/auto-deregister-sub?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/auto-deregister-sub/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/auto-deregister-sub/actions?query=workflow%3Adeploy)
+[![](https://img.shields.io/github/workflow/status/kaskadi/auto-deregister-sub/build?label=build&logo=mocha)](https://github.com/kaskadi/auto-deregister-sub/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/auto-deregister-sub/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/auto-deregister-sub/actions?query=workflow%3Asyntax-check)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/auto-deregister-sub?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auto-deregister-sub)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/auto-deregister-sub?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auto-deregister-sub)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/auto-deregister-sub?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auto-deregister-sub)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/auto-deregister-sub?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/auto-deregister-sub/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action inside of `deploy` workflow` and `docs/template.md` as template.

**New features**
- _documentation template:_ added documentation template under `docs/template.md`

**Updated features**
- _`deploy` workflow:_ added `generate-docs` job inside of `deploy` workflow. This uses `action-generate-docs` action as well as `docs/template.md` as template