### PR TITLE
Implemented static code analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'release/**'
       - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:
@@ -16,8 +17,29 @@ env:
   ES_SECRET: ${{ secrets.ES_SECRET }}
   ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   build:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,20 +18,55 @@ env:
   ES_SECRET: ${{ secrets.ES_SECRET }}
   ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
 jobs:
-  deploy:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12
-        registry-url: https://registry.npmjs.org/
+    - name: Install dependencies
+      run: npm i
+    - name: Test
+      run: npm test
+  syntax-check:
+    name: syntax-check
+    runs-on: ubuntu-latest
+    needs: analyze
+    steps:
+    - uses: actions/checkout@v2
     - name: Install dependencies
       run: npm i
     - name: serverless check
       uses: serverless/github-action@master
       with:
         args: deploy --noDeploy
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [test, syntax-check]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm i
     - name: serverless deploy
       uses: serverless/github-action@master
       with:

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'release/**'
       - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:

--- a/deregister-sub.js
+++ b/deregister-sub.js
@@ -7,3 +7,5 @@ module.exports.handler = async (event) => {
       return esRes
     })
 }
+
+// force

--- a/docs/template.md
+++ b/docs/template.md
@@ -15,10 +15,6 @@
 [![](https://img.shields.io/codeclimate/tech-debt/kaskadi/auto-deregister-sub?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auto-deregister-sub)
 [![](https://img.shields.io/codeclimate/coverage/kaskadi/auto-deregister-sub?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auto-deregister-sub)
 
-**LGTM**
-
-[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/auto-deregister-sub?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/auto-deregister-sub/?mode=list&logo=LGTM)
-
 <!-- You can add badges inside of this section if you'd like -->
 
 ****


### PR DESCRIPTION
**Changes description**
Added GitHub official static code analysis (via `CodeQL`, same as `LGTM`) inside of `build` and `deploy` workflows.

**Updated features**
- _`build`/`deploy` workflows:_ added static code analysis for vulnerability as a first step of the workflow. If this steps fails, the downstream steps will not run. Any vulnerabilities will be reported by the code analysis actions inside of the `Security` tab of the repository. Also fixed triggers.
- _`deploy` workflow:_ restructured workflow to first run static code analysis then unit tests and syntax check in parallel to then finish with deployment if all succeed.
- _`syntax-check` workflow:_ added `release/**` to trigger.
- _documentation template:_ updated badges accordingly.